### PR TITLE
マルチプレイ時にクライアントが落ちるバグを修正

### DIFF
--- a/Assets/Rules/BattleRoyal/RoyalManager.cs
+++ b/Assets/Rules/BattleRoyal/RoyalManager.cs
@@ -43,7 +43,7 @@ public class RoyalManager : RuleManager
         // If killer is Fighter.
         else if (0 <= killer_no && killer_no < GameInfo.MAX_PLAYER_COUNT)
         {
-            ScoreManager.I.individualScores[killer_no] += my_score;
+            ScoreManager.I.AddIndividualScore(killer_no, my_score);
         }
 
         // If killer is Zako.
@@ -54,11 +54,11 @@ public class RoyalManager : RuleManager
             switch (destroyer_team)
             {
                 case Team.RED:
-                    ScoreManager.I.individualScores[GameInfo.MAX_PLAYER_COUNT] += my_score;
+                    ScoreManager.I.AddIndividualScore(GameInfo.MAX_PLAYER_COUNT, my_score);
                     break;
 
                 case Team.BLUE:
-                    ScoreManager.I.individualScores[GameInfo.MAX_PLAYER_COUNT + 1] += my_score;
+                    ScoreManager.I.AddIndividualScore(GameInfo.MAX_PLAYER_COUNT + 1, my_score);
                     break;
 
                 default:

--- a/Assets/Scripts/Manager/ScoreManager.cs
+++ b/Assets/Scripts/Manager/ScoreManager.cs
@@ -137,5 +137,19 @@ public class ScoreManager : NetworkSingleton<ScoreManager>
 
 
     // Scores of each fighers & zakos of each team.
-    public NetworkList<int> individualScores;
+    NetworkList<int> individualScores;
+
+    public int GetIndividualScore(int idx) => individualScores[idx];
+
+    public void SetIndividualScore(int idx, int value)
+    {
+        if (!NetworkManager.Singleton.IsHost) return;
+        individualScores[idx] = value;
+    }
+
+    public void AddIndividualScore(int idx, int delta)
+    {
+        if (!NetworkManager.Singleton.IsHost) return;
+        individualScores[idx] += delta;
+    }
 }

--- a/Assets/Scripts/Manager/uGUIMannager.cs
+++ b/Assets/Scripts/Manager/uGUIMannager.cs
@@ -795,7 +795,7 @@ public class uGUIMannager : Singleton<uGUIMannager>
                     {
                         // Just set scores to UI.
                         int zako_no = no;
-                        seq.Join(DOTween.To(() => scores_float[zako_no], (value) => scores_float[zako_no] = value, ScoreManager.I.individualScores[zako_no], score_update_duration)
+                        seq.Join(DOTween.To(() => scores_float[zako_no], (value) => scores_float[zako_no] = value, ScoreManager.I.GetIndividualScore(zako_no), score_update_duration)
                             .OnUpdate(() => fighter_scores[zako_no].text = Mathf.CeilToInt(scores_float[zako_no]).ToString()));
                         continue;
                     }
@@ -822,7 +822,7 @@ public class uGUIMannager : Singleton<uGUIMannager>
 
                     // Set individual scores to UI.
                     int fighter_no = no;
-                    seq.Join(DOTween.To(() => scores_float[fighter_no], (value) => scores_float[fighter_no] = value, ScoreManager.I.individualScores[fighter_no], score_update_duration)
+                    seq.Join(DOTween.To(() => scores_float[fighter_no], (value) => scores_float[fighter_no] = value, ScoreManager.I.GetIndividualScore(fighter_no), score_update_duration)
                         .OnUpdate(() => fighter_scores[ui_idx].text = Mathf.CeilToInt(scores_float[fighter_no]).ToString()));
                 }
                 break;

--- a/Assets/Scripts/OnlineLobby/OnlineLobbyUI.cs
+++ b/Assets/Scripts/OnlineLobby/OnlineLobbyUI.cs
@@ -7,6 +7,7 @@ using TMPro;
 using Unity.Netcode;
 using Cysharp.Threading.Tasks;
 using System;
+using UnityEngine.Diagnostics;
 
 public class OnlineLobbyUI : Singleton<OnlineLobbyUI>
 {
@@ -504,6 +505,8 @@ public class OnlineLobbyUI : Singleton<OnlineLobbyUI>
     #region On Button Pressed Callbacks
     public void Host()
     {
+        // UnityEngine.Diagnostics.Utils.ForceCrash(ForcedCrashCategory.Abort);
+
         selectedHost = true;
         SetPage(Page.PUBLIC_PRIVATE);
     }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -158,7 +158,7 @@ PlayerSettings:
   androidSupportedAspectRatio: 1
   androidMaxAspectRatio: 2.1
   applicationIdentifier:
-    iPhone: com.DefaultCompany.MyGame5
+    iPhone: com.DefaultCompany.Air-Rampage
   buildNumber:
     Standalone: 0
     iPhone: 0
@@ -458,7 +458,7 @@ PlayerSettings:
   actionOnDotNetUnhandledException: 1
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
-  enableCrashReportAPI: 0
+  enableCrashReportAPI: 1
   cameraUsageDescription: 
   locationUsageDescription: 
   microphoneUsageDescription: 
@@ -808,7 +808,7 @@ PlayerSettings:
     Analytics: 1
     Build: 0
     Collab: 0
-    Game Performance: 0
+    Game Performance: 1
     Purchasing: 0
     UNet: 1
     Unity Ads: 0

--- a/ProjectSettings/UnityConnectSettings.asset
+++ b/ProjectSettings/UnityConnectSettings.asset
@@ -13,7 +13,7 @@ UnityConnectSettings:
   m_TestInitMode: 0
   CrashReportingSettings:
     m_EventUrl: https://perf-events.cloud.unity3d.com
-    m_Enabled: 0
+    m_Enabled: 1
     m_LogBufferSize: 10
     m_CaptureEditorExceptions: 1
   UnityPurchasingSettings:
@@ -23,6 +23,7 @@ UnityConnectSettings:
     m_Enabled: 1
     m_TestMode: 0
     m_InitializeOnStartup: 1
+    m_PackageRequiringCoreStatsPresent: 0
   UnityAdsSettings:
     m_Enabled: 0
     m_InitializeOnStartup: 1


### PR DESCRIPTION
## 原因
クライアントの戦闘機が撃墜された時に、[ScoreManager.cs > individualScores (NetworkList)](https://github.com/KenMat765/AirRampage/blob/92f913dd12bd0a7a299bc9e6ef410b548c788572/Assets/Scripts/Manager/ScoreManager.cs#L140) がクライアント側で編集しようとしてしまい、エラーが発生して落ちていた

## 解決策
individualScoresをSetter関数を介して編集するようにし、ホスト以外が編集できないように変更
https://github.com/KenMat765/AirRampage/blob/92f913dd12bd0a7a299bc9e6ef410b548c788572/Assets/Scripts/Manager/ScoreManager.cs#L144-L154